### PR TITLE
fix: use console.error instead of deprecated util.error

### DIFF
--- a/src/avrodoc.js
+++ b/src/avrodoc.js
@@ -62,7 +62,7 @@ function readJSON(filename) {
     try {
         parsed = JSON.parse(json);
     } catch (e) {
-        sys.error('Not a valid json file: ' + filename);
+        console.error('Not a valid json file: ' + filename);
         process.exit(1);
     }
     return parsed;

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,7 +13,6 @@
 const avrodoc = require('./avrodoc');
 const fs = require('fs');
 const path = require('path');
-const sys = require('util');
 const argv = require('optimist').alias('o', 'output').alias('i', 'input').alias('s', 'style').argv;
 const debug = require('debug')('avrodoc:cli');
 
@@ -38,7 +37,7 @@ const extra_less_files = argv.style ? [argv.style] : [];
 
 //valid input?
 if (!inputFiles || inputFiles.length === 0 || outputFile === null) {
-    sys.error('Usage: avrodoc [-i rootfolder] [my-schema.avsc [another-schema.avsc...]] [-o=my-documentation.html] [-s=my-style.less]');
+    console.error('Usage: avrodoc [-i rootfolder] [my-schema.avsc [another-schema.avsc...]] [-o=my-documentation.html] [-s=my-style.less]');
     process.exit(1);
 }
 avrodoc.createAvroDoc(extra_less_files, inputFiles, outputFile);


### PR DESCRIPTION
`util.error(..)` is deprecated: https://nodejs.org/api/deprecations.html#DEP0029