### PR TITLE
feat: make search case-insensitive

### DIFF
--- a/public/js/avrodoc.js
+++ b/public/js/avrodoc.js
@@ -215,18 +215,20 @@ function AvroDoc(input_schemata) {
 }
 
 function search(text, showNamespace) {
+    text = text.toLowerCase()
     console.log("Calling search", text, showNamespace);
     var schemas = $(".schema").map(function(index, e){
         var el = $(e);
         return {name: el.data("schema"), element: el, namespaceElement: el.parent()};
     });
     schemas.each(function(index, schema) {
-        if (schema.namespaceElement.data("schemas").includes(text) || schema.namespaceElement.data("namespace").includes(text)) {
+        if (schema.namespaceElement.data("schemas").toLowerCase().includes(text)
+            || schema.namespaceElement.data("namespace").toLowerCase().includes(text)) {
             schema.namespaceElement.show();
 
             if (showNamespace) {
                 schema.element.show();
-            } else if (schema.name.includes(text)) {
+            } else if (schema.name.toLowerCase().includes(text)) {
                 schema.element.show();
             } else {
                 schema.element.hide();


### PR DESCRIPTION
I have used this library a bit now, and the case sensitive search frustrates me a bit. I think it makes more sense to make this case insensitive?!

Example file generated from three avro-schemas showcasing case insensitive search: [out.zip](https://github.com/leosilvadev/avrodoc-plus/files/6322662/out.zip) (I wasn't allowed to upload HTML files, so this is an HTML file in a zip).
