### PR TITLE
Fix argument parser library argv

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest src/"
   },
   "dependencies": {
+    "arg": "^5.0.0",
     "debug": "^4.0.1",
     "dustjs-helpers": "1.1.0",
     "dustjs-linkedin": "1.1.1",
@@ -18,7 +19,6 @@
     "jest": "^23.6.0",
     "less": "1.3.0",
     "less-middleware": "0.1.7",
-    "optimist": "0.3.5",
     "uglify-js": "1.3.3",
     "underscore": "1.4.2"
   },

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,32 +13,43 @@
 const avrodoc = require('./avrodoc');
 const fs = require('fs');
 const path = require('path');
-const sys = require('util');
-const argv = require('optimist').alias('o', 'output').alias('i', 'input').alias('s', 'style').argv;
 const debug = require('debug')('avrodoc:cli');
+
+const argv = require('arg')(
+    {
+        '--output': String,
+        '-o': '--output',
+
+        '--input': String,
+        '-i': '--input',
+
+        '--style': String,
+        '-s': '--style',
+    }
+)
 
 let inputFiles = null;
 let outputFile = null;
 
 // Determine list of input files file1.avsc file2.avsc
 if (argv.input) {
-    debug('Collecting all avsc files from root folder ', argv.input);
-    inputFiles = collectInputFiles(argv.input);
-} else if (argv._) {
+    debug('Collecting all avsc files from root folder ', argv['--input']);
+    inputFiles = collectInputFiles(argv['--input']);
+} else if (argv._.length > 0) {
     debug('Using passed arguments as inputfiles...');
     inputFiles = argv._;
 }
 
 // Determine whether an output file is specified
-if (argv.output) {
-    outputFile = argv.output;
+if (argv['--output']) {
+    outputFile = argv['--output'];
 }
 
-const extra_less_files = argv.style ? [argv.style] : [];
+const extra_less_files = argv['--style'] ? [argv['--style']] : [];
 
 //valid input?
 if (!inputFiles || inputFiles.length === 0 || outputFile === null) {
-    sys.error('Usage: avrodoc [-i rootfolder] [my-schema.avsc [another-schema.avsc...]] [-o=my-documentation.html] [-s=my-style.less]');
+    sys.error('Usage: avrodoc [-i rootfolder] [my-schema.avsc [another-schema.avsc...]] [-o my-documentation.html] [-s my-style.less]');
     process.exit(1);
 }
 avrodoc.createAvroDoc(extra_less_files, inputFiles, outputFile);

--- a/src/cli.js
+++ b/src/cli.js
@@ -32,7 +32,7 @@ let inputFiles = null;
 let outputFile = null;
 
 // Determine list of input files file1.avsc file2.avsc
-if (argv.input) {
+if (argv['--input']) {
     debug('Collecting all avsc files from root folder ', argv['--input']);
     inputFiles = collectInputFiles(argv['--input']);
 } else if (argv._.length > 0) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,6 +98,11 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
 
+arg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-5.0.0.tgz#a20e2bb5710e82950a516b3f933fee5ed478be90"
+  integrity sha512-4P8Zm2H+BRS+c/xX1LrHw0qKpEhdlZjLCgWy+d78T9vqa2Z2SiD2wMrYuWIAFy5IZUD7nnNXroRttz+0RzlrzQ==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -2476,12 +2481,6 @@ once@^1.3.0, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
-
-optimist@0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.3.5.tgz#03654b52417030312d109f39b159825b60309304"
-  dependencies:
-    wordwrap "~0.0.2"
 
 optimist@^0.6.1:
   version "0.6.1"


### PR DESCRIPTION
optimist is no longer maintained: 
> DEPRECATION NOTICE
> I don't want to maintain this module anymore since I just use minimist, the argument parsing engine, directly instead nowadays.

Source: https://github.com/substack/node-optimist

[arg](https://github.com/vercel/arg) seems like a good and lightweight substitute.

Possible breaking change: `arg` does not interpret `=` in `-o=outfile.html`  as a separator, but rather a part of the filename: `=outfile.html`. 